### PR TITLE
Convert CI pipeline jobs to Jinja templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 terraform.tf
 aviator_pipeline.yml
+ci/jobs/management-dev.yml
+ci/jobs/management.yml

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ bootstrap: ## Bootstrap local environment for first use
 		export AWS_PROFILE=$(aws_profile); \
 		export AWS_REGION=$(aws_region); \
 		python3 bootstrap_terraform.py; \
+		python3 bootstrap_ci_pipeline.py; \
 	}
 	terraform fmt -recursive
 

--- a/aviator.yml
+++ b/aviator.yml
@@ -6,6 +6,9 @@ spruce:
   - with_in: ci/
     regexp: ".*yml"
   - with_in: ci/jobs/
+    except:
+    - management-dev.yml.j2
+    - management.yml.j2
   to: aviator_pipeline.yml
 fly:
   name: aws-concourse

--- a/bootstrap_ci_pipeline.py
+++ b/bootstrap_ci_pipeline.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import boto3
+import botocore
+import jinja2
+import os
+import sys
+import yaml
+
+
+def main():
+    if 'AWS_PROFILE' in os.environ:
+        boto3.setup_default_session(profile_name=os.environ['AWS_PROFILE'])
+    if 'AWS_REGION' in os.environ:
+        ssm = boto3.client('ssm', region_name=os.environ['AWS_REGION'])
+    else:
+        ssm = boto3.client('ssm')
+
+    try:
+        parameter = ssm.get_parameter(Name='terraform_bootstrap_config', WithDecryption=False)
+    except botocore.exceptions.ClientError as e:
+        error_message = e.response["Error"]["Message"]
+        if "The security token included in the request is invalid" in error_message:
+            print("ERROR: Invalid security token used when calling AWS SSM. Have you run `aws-sts` recently?")
+        else:
+            print("ERROR: Problem calling AWS SSM: {}".format(error_message))
+        sys.exit(1)
+
+    config_data = yaml.load(parameter['Parameter']['Value'], Loader=yaml.FullLoader)
+    with open('ci/jobs/management-dev.yml.j2') as in_template:
+        template = jinja2.Template(in_template.read())
+    with open('ci/jobs/management-dev.yml', 'w+') as pipeline:
+        pipeline.write(template.render(config_data))
+    with open('ci/jobs/management.yml.j2') as in_template:
+        template = jinja2.Template(in_template.read())
+    with open('ci/jobs/management.yml', 'w+') as pipeline:
+        pipeline.write(template.render(config_data))
+    print("Concourse pipeline config successfully created")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/ci/jobs/management-dev.yml.j2
+++ b/ci/jobs/management-dev.yml.j2
@@ -9,6 +9,10 @@ jobs:
   - .: (( inject meta.plan.terraform-plan ))
   - .: (( inject meta.plan.terraform-output ))
   - .: (( inject meta.plan.concourse-smoke-tests ))
+  - .: (( inject meta.plan.create-aws-profiles ))
+    config:
+      params:
+        AWS_ACC: "{{accounts['management-dev']}}"
   - .: (( inject meta.plan.generate-negative-proxy-test-manifest ))
   - .: (( inject meta.plan.generate-positive-proxy-test-manifest ))
   - .: (( inject meta.plan.run-positive-proxy-test ))

--- a/ci/jobs/management.yml.j2
+++ b/ci/jobs/management.yml.j2
@@ -19,6 +19,10 @@ jobs:
     params:
       TF_WORKSPACE: management
   - .: (( inject meta.plan.concourse-smoke-tests ))
+  - .: (( inject meta.plan.create-aws-profiles ))
+    config:
+      params:
+        AWS_ACC: "{{accounts['management']}}"
   - .: (( inject meta.plan.generate-negative-proxy-test-manifest ))
   - .: (( inject meta.plan.generate-positive-proxy-test-manifest ))
   - .: (( inject meta.plan.run-positive-proxy-test ))

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -144,6 +144,45 @@ meta:
           dir: concourse-smoke-tests
         inputs:
           - name: terraform-output
+    create-aws-profiles:
+      task: create-aws-profiles
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((docker-awscli.repository))
+            version: ((docker-awscli.version))
+            tag: ((docker-awscli.version))
+        outputs:
+          - name: .aws
+        params:
+          AWS_ACCESS_KEY_ID: ((ci.aws_access_key_id))
+          AWS_SECRET_ACCESS_KEY: ((ci.aws_secret_access_key))
+          AWS_PROFILE: ci
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            cat <<EOF> .aws/credentials
+            [default]
+            aws_access_key_id = $AWS_ACCESS_KEY_ID
+            aws_secret_access_key = $AWS_SECRET_ACCESS_KEY
+            [${AWS_PROFILE}]
+            role_arn = arn:aws:iam::${AWS_ACC}:role/${AWS_PROFILE}
+            source_profile = default
+            EOF
+            cat <<EOF> .aws/config
+            [default]
+            region = eu-west-2
+            [profile ${AWS_PROFILE}]
+            region = eu-west-2
+            s3 =
+              max_concurrent_requests = 5
+              signature_version = s3v4
+              addressing_style = virtual
+            EOF
     generate-positive-proxy-test-manifest:
       task: generate-positive-proxy-test-manifest
       config:


### PR DESCRIPTION
Some jobs now require sensitive info, so need to be run through a similar
process to the terraform config.