### PR TITLE
Provides read/write access to AWS Secrets Manager

### DIFF
--- a/terraform/modules/concourse_worker/iam.tf
+++ b/terraform/modules/concourse_worker/iam.tf
@@ -119,6 +119,11 @@ resource "aws_iam_role_policy_attachment" "worker_r53_full_access" {
   role       = aws_iam_role.worker.id
 }
 
+resource "aws_iam_role_policy_attachment" "worker_secretsmanager_full_access" {
+  policy_arn = "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
+  role       = aws_iam_role.worker.id
+}
+
 resource "aws_iam_role_policy_attachment" "worker_ci_custom" {
   policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/CICustom"
   role       = aws_iam_role.worker.id


### PR DESCRIPTION
This is a heavy AWS Managed policy.  Might need refactoring to strip some things out, but this should get us further beforehand.