### PR TITLE
Fixes reboot task when there are many nodes

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -259,9 +259,7 @@ meta:
           args:
             - -exc
             - |
-              INSTANCE_IDS=`aws ec2 describe-instances --filters Name=tag:Name,Values=concourse-worker | jq -r '.Reservations[].Instances[].InstanceId'`
-
-              for INSTANCE_ID in INSTANCE_IDS
+              for INSTANCE_ID in $(aws ec2 describe-instances --filters Name=tag:Name,Values=concourse-worker --profile dataworks-management-dev | jq -r '.Reservations[].Instances[].InstanceId');
               do
                 aws autoscaling set-instance-health --instance-id $INSTANCE_ID --health-status Unhealthy
               done
@@ -286,9 +284,7 @@ meta:
           args:
             - -exc
             - |
-              INSTANCE_IDS=`aws ec2 describe-instances --filters Name=tag:Name,Values=concourse-web | jq -r '.Reservations[].Instances[].InstanceId'`
-
-              for INSTANCE_ID in INSTANCE_IDS
+              for INSTANCE_ID in $(aws ec2 describe-instances --filters Name=tag:Name,Values=concourse-web --profile dataworks-management-dev | jq -r '.Reservations[].Instances[].InstanceId');
               do
                 aws autoscaling set-instance-health --instance-id $INSTANCE_ID --health-status Unhealthy
               done


### PR DESCRIPTION
When there was more than one node, the old way did not iterate correctly and failed.