### PR TITLE
DW-4079 - Enable waf-regional VPC endpoint, and for no_proxy, and bump VPC module

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -33,7 +33,7 @@ data "aws_secretsmanager_secret_version" "dataworks" {
 
 locals {
   amazon_region_domain  = "${data.aws_region.current.name}.amazonaws.com"
-  endpoint_services     = ["secretsmanager", "ec2messages", "s3", "monitoring", "ssm", "ssmmessages", "ec2", "kms", "logs", "api.ecr", "dkr.ecr", "ecs", "elasticloadbalancing", "events", "application-autoscaling"]
+  endpoint_services     = ["secretsmanager", "ec2messages", "s3", "monitoring", "ssm", "ssmmessages", "ec2", "kms", "logs", "api.ecr", "dkr.ecr", "ecs", "elasticloadbalancing", "events", "application-autoscaling", "waf-regional"]
   enterprise_github_url = jsondecode(data.aws_secretsmanager_secret_version.dataworks.secret_binary)["enterprise_github_url"]
 }
 

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source                                     = "dwp/vpc/aws"
-  version                                    = "2.0.8"
+  version                                    = "2.0.9"
   vpc_name                                   = "ci-cd"
   region                                     = data.aws_region.current.name
   vpc_cidr_block                             = var.vpc_cidr_block
@@ -24,5 +24,6 @@ module "vpc" {
   elasticloadbalancing_endpoint              = true
   events_endpoint                            = true
   application_autoscaling_endpoint           = true
+  waf_regional_endpoint                      = true
   common_tags                                = merge(var.tags, { Name = var.name })
 }


### PR DESCRIPTION
Signed-off-by: Benjamin Sherwood <benjaminsherwood@digital.uc.dwp.gov.uk>