### PR TITLE
DW-4108 - Enable Glue and EMR Endpoints

### DIFF
--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -25,5 +25,7 @@ module "vpc" {
   events_endpoint                            = true
   application_autoscaling_endpoint           = true
   kinesis_firehose_endpoint                  = true
+  glue_endpoint                              = true
+  emr_endpoint                               = true
   common_tags                                = merge(var.tags, { Name = var.name })
 }


### PR DESCRIPTION
Enabling the Glue and EMR Endpoints for the `ci-cd` VPC.