### PR TITLE
DW-4208 - Revert to config form for endpoint_services

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -33,11 +33,9 @@ data "aws_secretsmanager_secret_version" "dataworks" {
 
 locals {
   amazon_region_domain = "${data.aws_region.current.name}.amazonaws.com"
-  endpoint_services = join(",", concat(
-    ["secretsmanager", "ec2messages", "s3", "monitoring", "ssm", "ssmmessages", "ec2"],
-    ["kms", "logs", "api.ecr", "dkr.ecr", "ecs", "elasticloadbalancing", "events"],
-    ["application-autoscaling", "kinesis-firehose", "elasticmapreduce", "glue"]
-  ))
+  endpoint_services = ["secretsmanager", "ec2messages", "s3", "monitoring", "ssm", "ssmmessages", "ec2",
+    "kms", "logs", "api.ecr", "dkr.ecr", "ecs", "elasticloadbalancing", "events",
+  "application-autoscaling", "kinesis-firehose", "elasticmapreduce", "glue"]
   enterprise_github_url = jsondecode(data.aws_secretsmanager_secret_version.dataworks.secret_binary)["enterprise_github_url"]
 }
 


### PR DESCRIPTION
Turns out TF is actually fine with this list being multi-lined, previous plan failures must have been due to a typo.

Signed-off-by: Benjamin Sherwood <benjaminsherwood@digital.uc.dwp.gov.uk>