### PR TITLE
Turning on IMDSv2 in Launch Template

### DIFF
--- a/terraform/modules/concourse_web/asg.tf
+++ b/terraform/modules/concourse_web/asg.tf
@@ -78,6 +78,13 @@ resource "aws_launch_template" "web" {
   lifecycle {
     create_before_destroy = true
   }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
 }
 
 resource "aws_autoscaling_schedule" "web_night" {

--- a/terraform/modules/concourse_worker/asg.tf
+++ b/terraform/modules/concourse_worker/asg.tf
@@ -94,6 +94,13 @@ resource "aws_launch_template" "worker" {
   lifecycle {
     create_before_destroy = true
   }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
 }
 
 resource "aws_autoscaling_schedule" "worker_night" {


### PR DESCRIPTION
Turning on IMDSv2 in both web and worker instances of Concourse.  For ticket DW-4649.