### PR TITLE
Hiding stdout filled with secrets.  Added sleep

### DIFF
--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -309,6 +309,7 @@ meta:
           args:
             - -exc
             - |
+              set +x
               curl -Lk -o fly.tgz "https://github.com/concourse/concourse/releases/download/v6.1.0/fly-6.1.0-linux-amd64.tgz"
               tar -xvf fly.tgz
               chmod +x fly
@@ -318,7 +319,8 @@ meta:
               ./fly --target concourse workers
               for worker in $(./fly --target concourse workers  --json | jq -r .[].name);
               do
-                ./fly --target concourse land-worker --worker $worker;
+                ./fly --target concourse land-worker --worker $worker && 
+                sleep 300;
               done
 
     create-users:


### PR DESCRIPTION
We were showing a lot of secrets in stdout, so I've hidden that.
I added a `sleep` which is long enough for the worker to be landed and a new one to be brought up, before landing the next.  Hoping this fixes the issues seen when landing all workers simultaneously. 