### PR TITLE
Decreased auth timeout from default (24h) to 12h.

### DIFF
--- a/terraform/modules/concourse_web/variables.tf
+++ b/terraform/modules/concourse_web/variables.tf
@@ -102,3 +102,9 @@ variable "enterprise_github_certs" {
   description = "A list of certificates that make up the full CA chain that sign the Enterprise GitHub TlS certificates"
   default     = []
 }
+
+variable "auth_duration" {
+  type        = string
+  description = "Length of time for which tokens are valid. Afterwards, users will have to log back in"
+  default     = "12h"
+}

--- a/terraform/modules/concourse_web/web_config.tf
+++ b/terraform/modules/concourse_web/web_config.tf
@@ -9,8 +9,9 @@ locals {
 
   service_env_vars = merge(
     {
-      CONCOURSE_CLUSTER_NAME = var.name
-      CONCOURSE_EXTERNAL_URL = "https://${var.loadbalancer.fqdn}"
+      CONCOURSE_CLUSTER_NAME  = var.name
+      CONCOURSE_EXTERNAL_URL  = "https://${var.loadbalancer.fqdn}"
+      CONCOURSE_AUTH_DURATION = var.auth_duration
 
       CONCOURSE_ADD_LOCAL_USER       = "${jsondecode(data.aws_secretsmanager_secret_version.dataworks-secrets.secret_binary)["concourse_user"]}:${jsondecode(data.aws_secretsmanager_secret_version.dataworks-secrets.secret_binary)["concourse_password"]}"
       CONCOURSE_MAIN_TEAM_LOCAL_USER = jsondecode(data.aws_secretsmanager_secret_version.dataworks-secrets.secret_binary)["concourse_user"]


### PR DESCRIPTION
ITHC reflective change.  This is now consistent with our AWS auth duration.