### PR TITLE
add new `identity` team with local admin as owner and DW team as viewer

### DIFF
--- a/terraform/modules/concourse_web/templates/teams/identity/team.yml
+++ b/terraform/modules/concourse_web/templates/teams/identity/team.yml
@@ -1,0 +1,9 @@
+roles:
+  - name: owner
+    local:
+      users: ["${identity_owner}"]
+  - name: viewer
+    oidc:
+      groups: ["dataworks"]
+    github:
+      teams: ["dip:devops"]

--- a/terraform/modules/concourse_web/web_config.tf
+++ b/terraform/modules/concourse_web/web_config.tf
@@ -119,6 +119,13 @@ locals {
     {}
   )
 
+  identity = templatefile(
+    "${path.module}/templates/teams/identity/team.yml",
+    {
+      identity_owner = jsondecode(data.aws_secretsmanager_secret_version.dataworks-secrets.secret_binary)["concourse_user"]
+    }
+  )
+
   utility = templatefile(
     "${path.module}/templates/teams/utility/team.yml",
     {}
@@ -174,6 +181,11 @@ write_files:
     path: /root/teams/dataworks/team.yml
     permissions: '0600'
   - encoding: b64
+    content: ${base64encode(local.identity)}
+    owner: root:root
+    path: /root/teams/identity/team.yml
+    permissions: '0600'
+  - encoding: b64
     content: ${base64encode(local.utility)}
     owner: root:root
     path: /root/teams/utility/team.yml
@@ -199,6 +211,11 @@ EOF
   part {
     content_type = "text/plain"
     content      = local.dataworks
+  }
+
+  part {
+    content_type = "text/plain"
+    content      = local.identity
   }
 
   part {


### PR DESCRIPTION
Signed-off-by: danhill <danhill@digital.uc.dwp.gov.uk>

Deployed to mgt-dev and happy that team exists, is empty, can log in as local admin