### PR TITLE
Restore peering connection to UCFS

### DIFF
--- a/terraform/deploy/peering.tf
+++ b/terraform/deploy/peering.tf
@@ -4,20 +4,25 @@ resource "aws_vpc_peering_connection" "ucfs_github" {
   peer_region   = var.github_vpc.region
   vpc_id        = module.vpc.outputs.aws_vpc.id
 
-  # requester {
-  #   allow_classic_link_to_remote_vpc = false
-  #   allow_remote_vpc_dns_resolution  = true
-  #   allow_vpc_to_remote_classic_link = false
-  # }
+  tags = {
+    Name        = "ucfs_github"
+    Environment = local.environment
+  }
+
+  requester {
+    allow_classic_link_to_remote_vpc = false
+    allow_remote_vpc_dns_resolution  = true
+    allow_vpc_to_remote_classic_link = false
+  }
 
   lifecycle {
     prevent_destroy = true
   }
 }
 
-# resource "aws_route" "ucfs_github" {
-#   count                     = length(module.vpc.outputs.aws_route_table_private)
-#   route_table_id            = module.vpc.outputs.aws_route_table_private[count.index].id
-#   destination_cidr_block    = var.github_vpc.cidr_block
-#   vpc_peering_connection_id = aws_vpc_peering_connection.ucfs_github.id
-# }
+resource "aws_route" "ucfs_github" {
+  count                     = length(module.vpc.outputs.aws_route_table_private)
+  route_table_id            = module.vpc.outputs.aws_route_table_private[count.index].id
+  destination_cidr_block    = var.github_vpc.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.ucfs_github.id
+}


### PR DESCRIPTION
Now the peering connection has been accepted, we can restore the routes.  Also added additional tagging to include a name, so this isn't another blank entry in the console.