### PR TITLE
Run merge workflow when workflows are changed too

### DIFF
--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -5,6 +5,7 @@ on:
       - master
     paths:
       - "terraform/**"
+      - ".github/workflows/**"
 defaults:
   run:
     working-directory: terraform/deploy/


### PR DESCRIPTION
Unfortunately the way GHA works, if you make a mistake in the workflow, the job is all but lost.  This will at least trigger the push to master workflow, when the workflow has been fixed.