### PR TITLE
Issue fixed with recent RDS changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,5 @@ make terraform-apply
 ## Destroying
 Destroy isn't always possible from Terraform. Manual steps found to be:
 - remove prevent destroy in [terraform/modules/cloudwatch_log_group/log_group.tf](terraform/modules/cloudwatch_log_group/log_group.tf) (still valid 11/09/20)
-- Destroy RDS cluster if no snapshot exists (still valid 11/09/20)
-    - ```Error: RDS Cluster FinalSnapshotIdentifier is required when a final snapshot is required```
-    - Manually delete and if `mgmt-dev` choose no snapshot.
 - Delete NAT gateways (still valid 11/09/20)
 - The module.vpc.aws_route_table.public resource will remain, due to a peering connection to metrics infrastructure keeping everything alive. (valid 11/09/20))


### PR DESCRIPTION
This is no longer true, as the RDS cluster now creates its own final snapshot.