### PR TITLE
Add snapshot_identifier to ignore

### DIFF
--- a/terraform/modules/concourse_web/asg.tf
+++ b/terraform/modules/concourse_web/asg.tf
@@ -24,6 +24,9 @@ resource "aws_autoscaling_group" "web" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      max_size
+    ]
   }
 }
 

--- a/terraform/modules/database/rds.tf
+++ b/terraform/modules/database/rds.tf
@@ -40,7 +40,8 @@ resource "aws_rds_cluster" "cluster" {
 
   lifecycle {
     ignore_changes = [
-      engine_version
+      engine_version,
+      snapshot_identifier
     ]
   }
 }

--- a/terraform/modules/database/rds.tf
+++ b/terraform/modules/database/rds.tf
@@ -41,7 +41,7 @@ resource "aws_rds_cluster" "cluster" {
   lifecycle {
     ignore_changes = [
       engine_version,
-      snapshot_identifier
+      snapshot_identifier,
     ]
   }
 }


### PR DESCRIPTION
Adding `snapshot_identifier` to the ignore list, should prevent the RDS DB from being rebuilt when not intended.