### PR TITLE
change team permissions to `member`

### DIFF
--- a/terraform/modules/concourse_web/templates/teams/utility/team.yml
+++ b/terraform/modules/concourse_web/templates/teams/utility/team.yml
@@ -1,5 +1,5 @@
 roles:
-  - name: viewer
+  - name: member
     oidc:
       groups: ["dataworks"]
     github:


### PR DESCRIPTION
This is so we can move utility pipelines away from deployment pipelines, which provides a tidy grouping and the ability to set different permissions