### PR TITLE
Upgrade to 6.5.1

### DIFF
--- a/terraform/deploy/variables.tf
+++ b/terraform/deploy/variables.tf
@@ -15,7 +15,7 @@ variable "concourse" {
   type        = map(string)
 
   default = {
-    version = "6.4.1"
+    version = "6.5.1"
   }
 }
 


### PR DESCRIPTION
Upgrade Concourse to 6.5.1:

[Release notes](https://github.com/concourse/concourse/releases/tag/v6.5.1)