### PR TITLE
Uplift to AL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ aviator_pipeline.yml
 ci/jobs/management-dev.yml
 ci/jobs/management.yml
 ci/jobs/reboot-web-management.yml
+ci/jobs/reboot-web-management-dev.yml
 ci/jobs/reboot-worker-management.yml
 ci/jobs/reboot-worker-management-dev.yml
 ci/jobs/mgmt-user-admin.yml

--- a/bootstrap_ci_pipeline.py
+++ b/bootstrap_ci_pipeline.py
@@ -38,6 +38,10 @@ def main():
         template = jinja2.Template(in_template.read())
     with open('ci/jobs/reboot-worker-management.yml', 'w+') as pipeline:
         pipeline.write(template.render(config_data))
+    with open('ci/jobs/reboot-web-management-dev.yml.j2') as in_template:
+        template = jinja2.Template(in_template.read())
+    with open('ci/jobs/reboot-web-management-dev.yml', 'w+') as pipeline:
+        pipeline.write(template.render(config_data))
     with open('ci/jobs/reboot-worker-management-dev.yml.j2') as in_template:
         template = jinja2.Template(in_template.read())
     with open('ci/jobs/reboot-worker-management-dev.yml', 'w+') as pipeline:

--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -8,6 +8,9 @@ groups:
   - name: reboot-worker-nodes-dev
     jobs:
       - reboot-management-dev-worker-nodes
+  - name: reboot-web-nodes-dev
+    jobs:
+      - reboot-management-dev-web-node
   - name: user-administration
     jobs:
       - management-user-admin

--- a/ci/groups.yml
+++ b/ci/groups.yml
@@ -10,7 +10,7 @@ groups:
       - reboot-management-dev-worker-nodes
   - name: reboot-web-nodes-dev
     jobs:
-      - reboot-management-dev-web-node
+      - reboot-management-dev-web-nodes
   - name: user-administration
     jobs:
       - management-user-admin

--- a/ci/jobs/reboot-web-management-dev.yml.j2
+++ b/ci/jobs/reboot-web-management-dev.yml.j2
@@ -1,0 +1,10 @@
+jobs:
+- name: reboot-management-dev-web-nodes
+  plan:
+  - get: aws-concourse
+    trigger: false
+  - .: (( inject meta.plan.create-aws-profiles ))
+    config:
+      params:
+        AWS_ACC: "{{accounts['management-dev']}}"
+  - .: (( inject meta.plan.reboot-web-nodes ))

--- a/terraform/deploy/terraform.tfvars.j2
+++ b/terraform/deploy/terraform.tfvars.j2
@@ -1,7 +1,7 @@
 assume_role = "administrator"
 parent_domain_name    = "{{dataworks_domain_name}}"
 whitelist_cidr_blocks = ["{{ucfs['team_cidr_block']}}"]
-ami_filter_values = ["dw-concourse-ami-*"]
+ami_filter_values = ["dw-al2-concourse-ami-*"]
 ami_owners        = ["{{accounts['management']}}"]
 
 concourse_web_config = {

--- a/terraform/modules/concourse_web/web_config.tf
+++ b/terraform/modules/concourse_web/web_config.tf
@@ -24,15 +24,17 @@ locals {
       CONCOURSE_SESSION_SIGNING_KEY = "/etc/concourse/session_signing_key"
       CONCOURSE_TSA_AUTHORIZED_KEYS = "/etc/concourse/authorized_worker_keys"
       CONCOURSE_TSA_HOST_KEY        = "/etc/concourse/host_key"
+      CONCOURSE_TSA_LOG_LEVEL       = "error"
+      CONCOURSE_LOG_LEVEL           = "error"
 
       #TODO: Setup Monitoring !10
       CONCOURSE_PROMETHEUS_BIND_IP   = "0.0.0.0"
       CONCOURSE_PROMETHEUS_BIND_PORT = 9090
 
-      CONCOURSE_AWS_SECRETSMANAGER_REGION = data.aws_region.current.name
-      CONCOURSE_AWS_SECRETSMANAGER_PIPELINE_SECRET_TEMPLATE : "/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"
-      CONCOURSE_AWS_SECRETSMANAGER_TEAM_SECRET_TEMPLATE : "/concourse/{{.Team}}/{{.Secret}}"
-      CONCOURSE_SECRET_CACHE_DURATION = "1m"
+      CONCOURSE_AWS_SECRETSMANAGER_REGION                   = data.aws_region.current.name
+      CONCOURSE_AWS_SECRETSMANAGER_PIPELINE_SECRET_TEMPLATE = "/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}"
+      CONCOURSE_AWS_SECRETSMANAGER_TEAM_SECRET_TEMPLATE     = "/concourse/{{.Team}}/{{.Secret}}"
+      CONCOURSE_SECRET_CACHE_DURATION                       = "1m"
 
       # Cognito Auth
       CONCOURSE_OIDC_DISPLAY_NAME  = var.cognito_name
@@ -51,15 +53,15 @@ locals {
       CONCOURSE_CAPTURE_ERROR_METRICS = true
 
       #TODO: Audit logging
-      #CONCOURSE_ENABLE_BUILD_AUDITING     = true
-      #CONCOURSE_ENABLE_CONTAINER_AUDITING = true
-      #CONCOURSE_ENABLE_JOB_AUDITING       = true
-      #CONCOURSE_ENABLE_PIPELINE_AUDITING  = true
-      #CONCOURSE_ENABLE_RESOURCE_AUDITING  = true
-      #CONCOURSE_ENABLE_SYSTEM_AUDITING    = true
-      #CONCOURSE_ENABLE_TEAM_AUDITING      = true
-      #CONCOURSE_ENABLE_WORKER_AUDITING    = true
-      #CONCOURSE_ENABLE_VOLUME_AUDITING    = true
+      CONCOURSE_ENABLE_BUILD_AUDITING     = true
+      CONCOURSE_ENABLE_CONTAINER_AUDITING = true
+      CONCOURSE_ENABLE_JOB_AUDITING       = true
+      CONCOURSE_ENABLE_PIPELINE_AUDITING  = true
+      CONCOURSE_ENABLE_RESOURCE_AUDITING  = true
+      CONCOURSE_ENABLE_SYSTEM_AUDITING    = true
+      CONCOURSE_ENABLE_TEAM_AUDITING      = true
+      CONCOURSE_ENABLE_WORKER_AUDITING    = true
+      CONCOURSE_ENABLE_VOLUME_AUDITING    = true
 
       CONCOURSE_CONTAINER_PLACEMENT_STRATEGY : "random"
 

--- a/terraform/modules/concourse_worker/worker_config.tf
+++ b/terraform/modules/concourse_worker/worker_config.tf
@@ -18,6 +18,7 @@ locals {
       CONCOURSE_CERTS_DIR              = "/etc/ssl/certs"
       CONCOURSE_GARDEN_NETWORK_POOL    = "172.16.0.0/21"
       CONCOURSE_GARDEN_MAX_CONTAINERS  = "350"
+      CONCOURSE_LOG_LEVEL              = "error"
 
       HTTP_PROXY  = var.proxy.http_proxy
       HTTPS_PROXY = var.proxy.https_proxy


### PR DESCRIPTION
This PR:
- Uses the new AL2 Concourse AMI
- Sets logging on both web and worker nodes to `error` as `info` was all but useless and noisy
- Restored the admin job to cycle the web node in `mgmt-dev`
