### PR TITLE
Removes all but db secrets from TF state

### DIFF
--- a/bootstrap_terraform.py
+++ b/bootstrap_terraform.py
@@ -45,34 +45,12 @@ def main():
 
     config_data = yaml.load(
         parameter['Parameter']['Value'], Loader=yaml.FullLoader)
-    config_data['concourse_username'] = json.loads(
-        dataworks_secret['SecretBinary'])["concourse_user"]
-    config_data['concourse_password'] = json.loads(
-        dataworks_secret['SecretBinary'])["concourse_password"]
     config_data['database_username'] = json.loads(
         dataworks_secret['SecretBinary'])["database_user"]
     config_data['database_password'] = json.loads(
         dataworks_secret['SecretBinary'])["database_password"]
-    config_data['enterprise_github_oauth_client_id'] = json.loads(
-        dataworks_secret['SecretBinary'])["enterprise_github_oauth_client_id"]
-    config_data['enterprise_github_oauth_client_secret'] = json.loads(
-        dataworks_secret['SecretBinary'])["enterprise_github_oauth_client_secret"]
     config_data['enterprise_github_url'] = json.loads(
         concourse_secret['SecretBinary'])["enterprise_github_url"]
-    config_data['session_signing_key'] = json.loads(
-        dataworks_secret['SecretBinary'])["session_signing_key"]
-    config_data['session_signing_pub_key'] = json.loads(
-        dataworks_secret['SecretBinary'])["session_signing_pub_key"]
-    config_data['tsa_host_key'] = json.loads(
-        dataworks_secret['SecretBinary'])["tsa_host_key"]
-    config_data['tsa_host_pub_key'] = json.loads(
-        dataworks_secret['SecretBinary'])["tsa_host_pub_key"]
-    config_data['worker_key'] = json.loads(
-        dataworks_secret['SecretBinary'])["worker_key"]
-    config_data['worker_pub_key'] = json.loads(
-        dataworks_secret['SecretBinary'])["worker_pub_key"]
-    config_data['authorized_worker_keys'] = json.loads(
-        dataworks_secret['SecretBinary'])["authorized_worker_keys"]
     with open('terraform/deploy/terraform.tf.j2') as in_template:
         template = jinja2.Template(in_template.read())
     with open('terraform/deploy/terraform.tf', 'w+') as terraform_tf:

--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -39,7 +39,6 @@ module "concourse_web" {
 
   ami_id                = module.amis.ami_id
   concourse             = var.concourse
-  concourse_keys        = var.concourse_keys
   concourse_web_config  = var.concourse_web_config
   database              = module.database.outputs
   internal_loadbalancer = module.concourse_internal_lb.outputs
@@ -103,7 +102,6 @@ module "concourse_worker" {
 
   ami_id                  = module.amis.ami_id
   concourse               = var.concourse
-  concourse_keys          = var.concourse_keys
   internal_loadbalancer   = module.concourse_internal_lb.outputs
   loadbalancer            = module.concourse_lb.outputs
   log_group               = module.concourse_worker_log_group.outputs
@@ -156,8 +154,8 @@ module "database" {
   }
 
   database_credentials = {
-    username = var.concourse_web_config.database_username,
-    password = var.concourse_web_config.database_password,
+    username = var.concourse_web_config.database_username
+    password = var.concourse_web_config.database_password
   }
 }
 

--- a/terraform/deploy/terraform.tfvars.j2
+++ b/terraform/deploy/terraform.tfvars.j2
@@ -5,30 +5,9 @@ ami_filter_values = ["dw-al2-concourse-ami-*"]
 ami_owners        = ["{{accounts['management']}}"]
 
 concourse_web_config = {
-  concourse_username = "{{concourse_username}}"
-  concourse_password = "{{concourse_password}}"
   database_username = "{{database_username}}"
   database_password = "{{database_password}}"
-  enterprise_github_oauth_client_id = "{{enterprise_github_oauth_client_id}}"
-  enterprise_github_oauth_client_secret = "{{enterprise_github_oauth_client_secret}}"
   enterprise_github_url = "{{enterprise_github_url}}"
-}
-
-concourse_keys = {
-  session_signing_key     = <<EOT
-{{session_signing_key}}EOT
-  session_signing_pub_key = <<EOT
-{{session_signing_pub_key}}EOT
-  tsa_host_key            = <<EOT
-{{tsa_host_key}}EOT
-  tsa_host_pub_key        = <<EOT
-{{tsa_host_pub_key}}EOT
-  worker_key              = <<EOT
-{{worker_key}}EOT
-  worker_pub_key          = <<EOT
-{{worker_pub_key}}EOT
-  authorized_worker_keys  = <<EOT
-{{authorized_worker_keys}}EOT
 }
 
 github_vpc = {

--- a/terraform/deploy/variables.tf
+++ b/terraform/deploy/variables.tf
@@ -21,25 +21,9 @@ variable "concourse" {
 
 variable "concourse_web_config" {
   type = object({
-    concourse_username                    = string,
-    concourse_password                    = string,
-    database_username                     = string,
-    database_password                     = string,
-    enterprise_github_oauth_client_id     = string,
-    enterprise_github_oauth_client_secret = string,
-    enterprise_github_url                 = string,
-  })
-}
-
-variable "concourse_keys" {
-  type = object({
-    session_signing_key     = string,
-    session_signing_pub_key = string,
-    tsa_host_key            = string,
-    tsa_host_pub_key        = string,
-    worker_key              = string,
-    worker_pub_key          = string,
-    authorized_worker_keys  = string,
+    database_username     = string,
+    database_password     = string,
+    enterprise_github_url = string,
   })
 }
 

--- a/terraform/modules/concourse_web/templates/teams.sh
+++ b/terraform/modules/concourse_web/templates/teams.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 export HOME="/root"
+export AWS_DEFAULT_REGION=${aws_default_region}
 export CONCOURSE_USER=$(aws secretsmanager get-secret-value --secret-id /concourse/dataworks/dataworks-secrets --query SecretBinary --output text | base64 -d | jq -r .concourse_user)
 export CONCOURSE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /concourse/dataworks/dataworks-secrets --query SecretBinary --output text | base64 -d | jq -r .concourse_password)
 

--- a/terraform/modules/concourse_web/templates/teams.sh
+++ b/terraform/modules/concourse_web/templates/teams.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 export HOME="/root"
+export CONCOURSE_USER=$(aws secretsmanager get-secret-value --secret-id /concourse/dataworks/dataworks-secrets --query SecretBinary --output text | base64 -d | jq -r .concourse_user)
+export CONCOURSE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id /concourse/dataworks/dataworks-secrets --query SecretBinary --output text | base64 -d | jq -r .concourse_password)
 
 fly_tarball="/usr/local/concourse/fly-assets/fly-linux-amd64.tgz"
 mkdir -p $HOME/bin
@@ -7,8 +9,8 @@ tar -xzf $fly_tarball -C $HOME/bin/
 
 $HOME/bin/fly --target ${target} login \
 --concourse-url http://127.0.0.1:8080 \
---username ${concourse_username} \
---password ${concourse_password}
+--username $CONCOURSE_USER \
+--password $CONCOURSE_PASSWORD
 
 team_check=`$HOME/bin/fly -t aws-concourse teams | grep -v name | grep -v main`
 

--- a/terraform/modules/concourse_web/templates/teams/identity/team.yml
+++ b/terraform/modules/concourse_web/templates/teams/identity/team.yml
@@ -1,7 +1,4 @@
 roles:
-  - name: owner
-    local:
-      users: ["${CONCOURSE_USER}"]
   - name: viewer
     oidc:
       groups: ["dataworks"]

--- a/terraform/modules/concourse_web/templates/teams/identity/team.yml
+++ b/terraform/modules/concourse_web/templates/teams/identity/team.yml
@@ -1,7 +1,7 @@
 roles:
   - name: owner
     local:
-      users: ["${identity_owner}"]
+      users: ["${CONCOURSE_USER}"]
   - name: viewer
     oidc:
       groups: ["dataworks"]

--- a/terraform/modules/concourse_web/templates/web_systemd
+++ b/terraform/modules/concourse_web/templates/web_systemd
@@ -5,6 +5,7 @@ After=basic.target network.target
 # OnFailure=poweroff.target
 
 [Service]
+EnvironmentFile=/etc/systemd/system/concourse-web.env
 %{ for key, value in environment_vars ~}
 Environment=${key}=${value}
 %{ endfor ~}

--- a/terraform/modules/concourse_web/variables.tf
+++ b/terraform/modules/concourse_web/variables.tf
@@ -10,7 +10,6 @@ variable "tags" {
 
 variable "ami_id" {}
 variable "concourse" {}
-variable "concourse_keys" {}
 variable "database" {}
 variable "internal_loadbalancer" {}
 variable "loadbalancer" {}
@@ -25,13 +24,9 @@ variable "cognito_name" {}
 
 variable "concourse_web_config" {
   type = object({
-    concourse_username                    = string,
-    concourse_password                    = string,
-    database_username                     = string,
-    database_password                     = string,
-    enterprise_github_oauth_client_id     = string,
-    enterprise_github_oauth_client_secret = string,
-    enterprise_github_url                 = string,
+    database_username     = string,
+    database_password     = string,
+    enterprise_github_url = string,
   })
 }
 

--- a/terraform/modules/concourse_web/web_config.tf
+++ b/terraform/modules/concourse_web/web_config.tf
@@ -103,13 +103,19 @@ locals {
   teams = templatefile(
     "${path.module}/templates/teams.sh",
     {
-      target            = "aws-concourse"
-      concourse_version = var.concourse.version
+      aws_default_region = data.aws_region.current.name
+      target             = "aws-concourse"
+      concourse_version  = var.concourse.version
     }
   )
 
   dataworks = templatefile(
     "${path.module}/templates/teams/dataworks/team.yml",
+    {}
+  )
+
+  identity = templatefile(
+    "${path.module}/templates/teams/identity/team.yml",
     {}
   )
 
@@ -168,6 +174,7 @@ write_files:
     path: /root/teams/dataworks/team.yml
     permissions: '0600'
   - encoding: b64
+    content: ${base64encode(local.identity)}
     owner: root:root
     path: /root/teams/identity/team.yml
     permissions: '0600'
@@ -197,6 +204,11 @@ EOF
   part {
     content_type = "text/plain"
     content      = local.dataworks
+  }
+
+  part {
+    content_type = "text/plain"
+    content      = local.identity
   }
 
   part {

--- a/terraform/modules/concourse_web/web_config.tf
+++ b/terraform/modules/concourse_web/web_config.tf
@@ -13,13 +13,8 @@ locals {
       CONCOURSE_EXTERNAL_URL  = "https://${var.loadbalancer.fqdn}"
       CONCOURSE_AUTH_DURATION = var.auth_duration
 
-      CONCOURSE_ADD_LOCAL_USER       = "${var.concourse_web_config.concourse_username}:${var.concourse_web_config.concourse_password}"
-      CONCOURSE_MAIN_TEAM_LOCAL_USER = var.concourse_web_config.concourse_username
-
       CONCOURSE_POSTGRES_DATABASE = var.database.database_name
       CONCOURSE_POSTGRES_HOST     = var.database.endpoint
-      CONCOURSE_POSTGRES_PASSWORD = var.concourse_web_config.database_password
-      CONCOURSE_POSTGRES_USER     = var.concourse_web_config.database_username
 
       CONCOURSE_SESSION_SIGNING_KEY = "/etc/concourse/session_signing_key"
       CONCOURSE_TSA_AUTHORIZED_KEYS = "/etc/concourse/authorized_worker_keys"
@@ -45,9 +40,7 @@ locals {
       CONCOURSE_OIDC_USER_NAME_KEY = "cognito:username"
 
       # UC GitHub Auth
-      CONCOURSE_GITHUB_CLIENT_ID     = var.concourse_web_config.enterprise_github_oauth_client_id
-      CONCOURSE_GITHUB_CLIENT_SECRET = var.concourse_web_config.enterprise_github_oauth_client_secret
-      CONCOURSE_GITHUB_HOST          = var.concourse_web_config.enterprise_github_url
+      CONCOURSE_GITHUB_HOST = var.concourse_web_config.enterprise_github_url
 
       CONCOURSE_METRICS_HOST_NAME     = local.name
       CONCOURSE_CAPTURE_ERROR_METRICS = true
@@ -63,7 +56,7 @@ locals {
       CONCOURSE_ENABLE_WORKER_AUDITING    = true
       CONCOURSE_ENABLE_VOLUME_AUDITING    = true
 
-      CONCOURSE_CONTAINER_PLACEMENT_STRATEGY : "random"
+      CONCOURSE_CONTAINER_PLACEMENT_STRATEGY = "random"
 
       HTTP_PROXY  = var.proxy.http_proxy
       HTTPS_PROXY = var.proxy.https_proxy
@@ -110,23 +103,14 @@ locals {
   teams = templatefile(
     "${path.module}/templates/teams.sh",
     {
-      target             = "aws-concourse"
-      concourse_version  = var.concourse.version
-      concourse_username = var.concourse_web_config.concourse_username
-      concourse_password = var.concourse_web_config.concourse_password
+      target            = "aws-concourse"
+      concourse_version = var.concourse.version
     }
   )
 
   dataworks = templatefile(
     "${path.module}/templates/teams/dataworks/team.yml",
     {}
-  )
-
-  identity = templatefile(
-    "${path.module}/templates/teams/identity/team.yml",
-    {
-      identity_owner = var.concourse_web_config.concourse_username
-    }
   )
 
   utility = templatefile(
@@ -184,7 +168,6 @@ write_files:
     path: /root/teams/dataworks/team.yml
     permissions: '0600'
   - encoding: b64
-    content: ${base64encode(local.identity)}
     owner: root:root
     path: /root/teams/identity/team.yml
     permissions: '0600'
@@ -214,11 +197,6 @@ EOF
   part {
     content_type = "text/plain"
     content      = local.dataworks
-  }
-
-  part {
-    content_type = "text/plain"
-    content      = local.identity
   }
 
   part {

--- a/terraform/modules/concourse_worker/variables.tf
+++ b/terraform/modules/concourse_worker/variables.tf
@@ -10,7 +10,6 @@ variable "tags" {
 
 variable "ami_id" {}
 variable "concourse" {}
-variable "concourse_keys" {}
 variable "internal_loadbalancer" {}
 variable "loadbalancer" {}
 variable "log_group" {}


### PR DESCRIPTION
This removes all but DB secrets from TF state in Concourse.
It now gets them during the nodes bootstrap script run, and adds them to the systemd upstart file.