### PR TITLE
remove upgrade path from TF

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -38,7 +38,6 @@ module "concourse_web" {
   )
 
   ami_id                = module.amis.ami_id
-  concourse             = var.concourse
   concourse_web_config  = var.concourse_web_config
   database              = module.database.outputs
   internal_loadbalancer = module.concourse_internal_lb.outputs
@@ -101,7 +100,6 @@ module "concourse_worker" {
   )
 
   ami_id                  = module.amis.ami_id
-  concourse               = var.concourse
   internal_loadbalancer   = module.concourse_internal_lb.outputs
   loadbalancer            = module.concourse_lb.outputs
   log_group               = module.concourse_worker_log_group.outputs

--- a/terraform/deploy/variables.tf
+++ b/terraform/deploy/variables.tf
@@ -10,15 +10,6 @@ variable "lb_name" {
   default     = "ci"
 }
 
-variable "concourse" {
-  description = "concourse version to install"
-  type        = map(string)
-
-  default = {
-    version = "6.4.1"
-  }
-}
-
 variable "concourse_web_config" {
   type = object({
     database_username     = string,

--- a/terraform/modules/concourse_web/templates/web_bootstrap.sh
+++ b/terraform/modules/concourse_web/templates/web_bootstrap.sh
@@ -17,12 +17,6 @@ CONCOURSE_GITHUB_CLIENT_SECRET=$(aws secretsmanager get-secret-value --secret-id
 CONCOURSE_MAIN_TEAM_LOCAL_USER=$CONCOURSE_USER
 EOF
 
-
-concourse_tarball="concourse-${concourse_version}-linux-amd64.tgz"
-https_proxy="${https_proxy}" curl -s -L -O https://github.com/concourse/concourse/releases/download/v${concourse_version}/$concourse_tarball
-tar -xzf $concourse_tarball -C /usr/local
-rm $concourse_tarball
-
 mkdir /etc/concourse
 
 aws secretsmanager get-secret-value --secret-id /concourse/dataworks/dataworks-secrets --query SecretBinary --output text | base64 -d | jq -r .session_signing_key > /etc/concourse/session_signing_key

--- a/terraform/modules/concourse_web/variables.tf
+++ b/terraform/modules/concourse_web/variables.tf
@@ -9,7 +9,6 @@ variable "tags" {
 }
 
 variable "ami_id" {}
-variable "concourse" {}
 variable "database" {}
 variable "internal_loadbalancer" {}
 variable "loadbalancer" {}

--- a/terraform/modules/concourse_web/web_config.tf
+++ b/terraform/modules/concourse_web/web_config.tf
@@ -92,7 +92,6 @@ locals {
     "${path.module}/templates/web_bootstrap.sh",
     {
       aws_default_region      = data.aws_region.current.name
-      concourse_version       = var.concourse.version
       http_proxy              = var.proxy.http_proxy
       https_proxy             = var.proxy.https_proxy
       no_proxy                = var.proxy.no_proxy
@@ -105,7 +104,6 @@ locals {
     {
       aws_default_region = data.aws_region.current.name
       target             = "aws-concourse"
-      concourse_version  = var.concourse.version
     }
   )
 

--- a/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
+++ b/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
@@ -4,11 +4,6 @@ set -euxo pipefail
 
 export AWS_DEFAULT_REGION=${aws_default_region}
 
-concourse_tarball="concourse-${concourse_version}-linux-amd64.tgz"
-https_proxy="${https_proxy}" curl -s -L -O https://github.com/concourse/concourse/releases/download/v${concourse_version}/$concourse_tarball
-tar -xzf $concourse_tarball -C /usr/local
-rm $concourse_tarball
-
 mkdir /etc/concourse
 
 aws secretsmanager get-secret-value --secret-id /concourse/dataworks/dataworks-secrets --query SecretBinary --output text | base64 -d | jq -r .tsa_host_pub_key > /etc/concourse/tsa_host_key.pub

--- a/terraform/modules/concourse_worker/variables.tf
+++ b/terraform/modules/concourse_worker/variables.tf
@@ -9,7 +9,6 @@ variable "tags" {
 }
 
 variable "ami_id" {}
-variable "concourse" {}
 variable "internal_loadbalancer" {}
 variable "loadbalancer" {}
 variable "log_group" {}

--- a/terraform/modules/concourse_worker/worker_config.tf
+++ b/terraform/modules/concourse_worker/worker_config.tf
@@ -47,7 +47,6 @@ locals {
   worker_bootstrap_file = templatefile(
     "${path.module}/templates/worker_bootstrap.sh",
     {
-      concourse_version       = var.concourse.version
       aws_default_region      = data.aws_region.current.name
       http_proxy              = var.proxy.http_proxy
       https_proxy             = var.proxy.https_proxy


### PR DESCRIPTION
Remove the ability to upgrade Concourse from within the infra.

The correct pattern is to build a new AMI.