### PR TITLE
Published AMIs for mgmt, PR AMIs for mgmt-dev

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -2,8 +2,8 @@ module "amis" {
   source = "../modules/amis"
 
   ami_filter_name   = var.ami_filter_name
-  ami_filter_values = var.ami_filter_values
-  ami_owners        = var.ami_owners
+  ami_filter_values = local.ami_filter_values
+  ami_owners        = local.ami_owners
 }
 
 module "concourse_lb" {

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -153,6 +153,10 @@ locals {
 
   no_proxy = "${join(",", module.vpc.outputs.no_proxy_list)},${var.concourse_web_config.enterprise_github_url}"
 
+  ami_filter_values = local.environment == "management" ? ["dw-al2-concourse-ami-*"] : ["pr-dw-al2-concourse-ami-*"]
+
+  ami_owners = [local.account[local.environment]]
+
   enterprise_github_certs = [
     "s3://dw-${local.environment}-public-certificates/ca_certificates/ucfs/ucd_ca.pem",
     "s3://dw-${local.environment}-public-certificates/ca_certificates/ucfs/ucd_clientca.pem"

--- a/terraform/deploy/terraform.tfvars.j2
+++ b/terraform/deploy/terraform.tfvars.j2
@@ -1,8 +1,6 @@
 assume_role = "administrator"
 parent_domain_name    = "{{dataworks_domain_name}}"
 whitelist_cidr_blocks = ["{{ucfs['team_cidr_block']}}"]
-ami_filter_values = ["dw-al2-concourse-ami-*"]
-ami_owners        = ["{{accounts['management']}}"]
 
 concourse_web_config = {
   database_username = "{{database_username}}"

--- a/terraform/deploy/variables.tf
+++ b/terraform/deploy/variables.tf
@@ -33,16 +33,6 @@ variable "ami_filter_name" {
   default = "name"
 }
 
-variable "ami_filter_values" {
-  type    = list(string)
-  default = ["amzn2-ami-hvm-2.0.*-x86_64-gp2"]
-}
-
-variable "ami_owners" {
-  type    = list(string)
-  default = ["self", "amazon"]
-}
-
 variable "concourse_no_proxy" {
   type    = string
   default = "169.254.169.254,169.254.169.123,.amazonaws.com"


### PR DESCRIPTION
This change makes it so `management-dev` only uses PR builds of AMIs, and `management` only uses published AMIs, allowing for a proper development path to production.
