### PR TITLE
set CONCOURSE_PEER_ADDRESS to localhost

### DIFF
--- a/terraform/modules/concourse_web/web_config.tf
+++ b/terraform/modules/concourse_web/web_config.tf
@@ -73,7 +73,7 @@ locals {
     {
       environment_vars = merge(local.service_env_vars,
         {
-          CONCOURSE_PEER_ADDRESS = "%H"
+          CONCOURSE_PEER_ADDRESS = "127.0.0.1"
       })
     }
   )


### PR DESCRIPTION
Fixes workers not being able to register in v`6.5.0` and above.