### PR TITLE
Allow changing of worker hostnames and tags

### DIFF
--- a/terraform/modules/concourse_worker/iam.tf
+++ b/terraform/modules/concourse_worker/iam.tf
@@ -87,3 +87,25 @@ resource "aws_iam_role_policy_attachment" "concourse_worker_secrets" {
   policy_arn = aws_iam_policy.concourse_secrets_read.arn
   role       = data.aws_iam_role.worker.id
 }
+
+data "aws_iam_policy_document" "concourse_tag_ec2" {
+  statement {
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:CreateTags"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "concourse_tag_ec2" {
+  name        = "${local.name}EC2"
+  description = "Change Concourse Worker's Tags"
+  policy      = data.aws_iam_policy_document.concourse_tag_ec2.json
+}
+
+resource "aws_iam_role_policy_attachment" "concourse_tag_ec2" {
+  policy_arn = aws_iam_policy.concourse_tag_ec2.arn
+  role       = data.aws_iam_role.worker.id
+}

--- a/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
+++ b/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
@@ -3,6 +3,14 @@
 set -euxo pipefail
 
 export AWS_DEFAULT_REGION=${aws_default_region}
+export DATE=$(date +%H%M%S%d%m%y)
+export HOSTNAME=${name}-$DATE
+TOKEN=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" "http://169.254.169.254/latest/api/token")
+export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token:$TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)
+
+hostnamectl set-hostname $HOSTNAME
+aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$HOSTNAME
+
 
 mkdir /etc/concourse
 

--- a/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
+++ b/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
@@ -3,11 +3,11 @@
 set -euxo pipefail
 
 export AWS_DEFAULT_REGION=${aws_default_region}
-export DATE=$(date +%y%m%d%H%M%S)
+UUID=$(uuidgen)
 TOKEN=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" "http://169.254.169.254/latest/api/token")
 export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token:$TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)
 export AWS_AZ=$(curl -H "X-aws-ec2-metadata-token:$TOKEN" -s http://169.254.169.254/latest/dynamic/instance-identity/document|grep availabilityZone|awk -F\" '{print $4}')
-export HOSTNAME=${name}-$AWS_AZ-$DATE
+export HOSTNAME=${name}-$AWS_AZ-$UUID
 
 hostnamectl set-hostname $HOSTNAME
 aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$HOSTNAME

--- a/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
+++ b/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
@@ -3,10 +3,11 @@
 set -euxo pipefail
 
 export AWS_DEFAULT_REGION=${aws_default_region}
-export DATE=$(date +%H%M%S%d%m%y)
-export HOSTNAME=${name}-$DATE
+export DATE=$(date +%y%m%d%H%M%S)
 TOKEN=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" "http://169.254.169.254/latest/api/token")
 export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token:$TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)
+export AWS_AZ=$(curl -H "X-aws-ec2-metadata-token:$TOKEN" -s http://169.254.169.254/latest/dynamic/instance-identity/document|grep availabilityZone|awk -F\" '{print $4}')
+export HOSTNAME=${name}-$AWS_AZ-$DATE
 
 hostnamectl set-hostname $HOSTNAME
 aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Name,Value=$HOSTNAME

--- a/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
+++ b/terraform/modules/concourse_worker/templates/worker_bootstrap.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 export AWS_DEFAULT_REGION=${aws_default_region}
-UUID=$(uuidgen)
+UUID=$(dbus-uuidgen --get | cut -c 1-8)
 TOKEN=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" "http://169.254.169.254/latest/api/token")
 export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token:$TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id)
 export AWS_AZ=$(curl -H "X-aws-ec2-metadata-token:$TOKEN" -s http://169.254.169.254/latest/dynamic/instance-identity/document|grep availabilityZone|awk -F\" '{print $4}')

--- a/terraform/modules/concourse_worker/worker_config.tf
+++ b/terraform/modules/concourse_worker/worker_config.tf
@@ -52,6 +52,7 @@ locals {
       https_proxy             = var.proxy.https_proxy
       no_proxy                = var.proxy.no_proxy
       enterprise_github_certs = "${join(" ", var.enterprise_github_certs)}"
+      name                    = local.name
     }
   )
 


### PR DESCRIPTION
In order to not preset IP addresses on dashboards, we apply hostnames and EC2 Name tags.