### PR TITLE
Use GP3 not io1 and get equivalent IOPS but shrink mgmt dev by half d…

### DIFF
--- a/terraform/deploy/locals.tf
+++ b/terraform/deploy/locals.tf
@@ -30,12 +30,22 @@ locals {
     management     = false
   }
 
-  ebs_volume_size = {
+  ebs_volume_size_web = {
     management-dev = 334
     management     = 667
   }
 
-  ebs_volume_type = {
+  ebs_volume_type_web = {
+    management-dev = "gp3"
+    management     = "gp3"
+  }
+
+  ebs_volume_size_worker = {
+    management-dev = 334
+    management     = 667
+  }
+
+  ebs_volume_type_worker = {
     management-dev = "gp3"
     management     = "gp3"
   }

--- a/terraform/deploy/locals.tf
+++ b/terraform/deploy/locals.tf
@@ -30,25 +30,5 @@ locals {
     management     = false
   }
 
-  ebs_volume_size_web = {
-    management-dev = 334
-    management     = 667
-  }
-
-  ebs_volume_type_web = {
-    management-dev = "gp3"
-    management     = "gp3"
-  }
-
-  ebs_volume_size_worker = {
-    management-dev = 334
-    management     = 667
-  }
-
-  ebs_volume_type_worker = {
-    management-dev = "gp3"
-    management     = "gp3"
-  }
-
   kali_users = jsondecode(data.aws_secretsmanager_secret_version.internet_ingress.secret_binary)["ssh_bastion_users"]
 }

--- a/terraform/deploy/locals.tf
+++ b/terraform/deploy/locals.tf
@@ -30,5 +30,15 @@ locals {
     management     = false
   }
 
+  ebs_volume_size = {
+    management-dev = 334
+    management     = 667
+  }
+
+  ebs_volume_type = {
+    management-dev = "gp3"
+    management     = "gp3"
+  }
+
   kali_users = jsondecode(data.aws_secretsmanager_secret_version.internet_ingress.secret_binary)["ssh_bastion_users"]
 }

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -66,7 +66,7 @@ variable "region" {
 }
 
 provider "aws" {
-  version = "~> 2.62.0"
+  version = "~> 3.25.0"
   region  = var.region
 
   assume_role {
@@ -75,7 +75,7 @@ provider "aws" {
 }
 
 provider "aws" {
-  version = "~> 2.62.0"
+  version = "~> 3.25.0"
   region  = "{{provider_region}}"
   alias   = "ssh_bastion"
 

--- a/terraform/modules/concourse_web/asg.tf
+++ b/terraform/modules/concourse_web/asg.tf
@@ -44,8 +44,8 @@ resource "aws_launch_template" "web" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      volume_type           = local.ebs_volume_type[local.environment]
-      volume_size           = local.ebs_volume_size[local.environment]
+      volume_type           = local.ebs_volume_type_worker[local.environment]
+      volume_size           = local.ebs_volume_size_worker[local.environment]
     }
   }
 

--- a/terraform/modules/concourse_web/asg.tf
+++ b/terraform/modules/concourse_web/asg.tf
@@ -44,8 +44,8 @@ resource "aws_launch_template" "web" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      volume_type           = local.ebs_volume_type_worker[local.environment]
-      volume_size           = local.ebs_volume_size_worker[local.environment]
+      volume_type           = local.ebs_volume_type_web[local.environment]
+      volume_size           = local.ebs_volume_size_web[local.environment]
     }
   }
 

--- a/terraform/modules/concourse_web/asg.tf
+++ b/terraform/modules/concourse_web/asg.tf
@@ -44,9 +44,8 @@ resource "aws_launch_template" "web" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      volume_type           = "io1"
-      iops                  = 2000
-      volume_size           = 40
+      volume_type           = local.ebs_volume_type[local.environment]
+      volume_size           = local.ebs_volume_size[local.environment]
     }
   }
 

--- a/terraform/modules/concourse_web/locals.tf
+++ b/terraform/modules/concourse_web/locals.tf
@@ -1,3 +1,15 @@
 locals {
   name = "${var.name}-concourse-web"
+
+  environment = terraform.workspace == "default" ? "management-dev" : terraform.workspace
+
+  ebs_volume_size_web = {
+    management-dev = 334
+    management     = 667
+  }
+
+  ebs_volume_type_web = {
+    management-dev = "gp3"
+    management     = "gp3"
+  }
 }

--- a/terraform/modules/concourse_web/providers.tf
+++ b/terraform/modules/concourse_web/providers.tf
@@ -1,5 +1,5 @@
 terraform {
   required_providers {
-    aws = ">= 2.62.0"
+    aws = ">= 3.25.0"
   }
 }

--- a/terraform/modules/concourse_worker/asg.tf
+++ b/terraform/modules/concourse_worker/asg.tf
@@ -57,9 +57,8 @@ resource "aws_launch_template" "worker" {
     ebs {
       delete_on_termination = true
       encrypted             = true
-      volume_type           = "io1"
-      iops                  = 2000
-      volume_size           = 100
+      volume_type           = local.ebs_volume_type_worker[local.environment]
+      volume_size           = local.ebs_volume_size_worker[local.environment]
     }
   }
 

--- a/terraform/modules/concourse_worker/locals.tf
+++ b/terraform/modules/concourse_worker/locals.tf
@@ -1,4 +1,17 @@
 locals {
   name         = "${var.name}-concourse-worker"
+
+  environment = terraform.workspace == "default" ? "management-dev" : terraform.workspace
+
   service_port = 2222
+
+  ebs_volume_size_worker = {
+    management-dev = 334
+    management     = 667
+  }
+
+  ebs_volume_type_worker = {
+    management-dev = "gp3"
+    management     = "gp3"
+  }
 }

--- a/terraform/modules/loadbalancer/dns.tf
+++ b/terraform/modules/loadbalancer/dns.tf
@@ -16,10 +16,10 @@ resource "aws_acm_certificate" "concourse" {
 }
 
 resource "aws_route53_record" "concourse_validation" {
-  name    = aws_acm_certificate.concourse.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.concourse.domain_validation_options.0.resource_record_type
+  name    = tolist(aws_acm_certificate.concourse.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.concourse.domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.main.id
-  records = [aws_acm_certificate.concourse.domain_validation_options.0.resource_record_value]
+  records = [tolist(aws_acm_certificate.concourse.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 

--- a/terraform/modules/loadbalancer/lb.tf
+++ b/terraform/modules/loadbalancer/lb.tf
@@ -45,7 +45,8 @@ resource "aws_lb_listener_rule" "https" {
   }
 
   condition {
-    field  = "host-header"
-    values = [local.fqdn]
+    host_header {
+        values = [local.fqdn]
+    }
   }
 }


### PR DESCRIPTION
Use GP3 not io1 and get equivalent IOPS but shrink mgmt dev by half due to load.

Updated syntax for new AWS provider.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_lb_listener_rule

https://github.com/hashicorp/terraform-provider-aws/pull/14199/files/012f5b96ec2c4ef956095ddb26936effcd1e43aa#diff-74c6ea0cd1143c75ed79bac5ad3e03fa4c709e1751240396d5ea3c768836b02c