### PR TITLE
VPN ignores size rule, restore to smaller size

### DIFF
--- a/terraform/modules/waf/waf_condition_size.tf
+++ b/terraform/modules/waf/waf_condition_size.tf
@@ -16,7 +16,7 @@ resource "aws_wafregional_size_constraint_set" "size_restrictions" {
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "1048576"
+    size                = "262144"
 
     field_to_match {
       type = "BODY"

--- a/terraform/modules/waf/waf_rule.tf
+++ b/terraform/modules/waf/waf_rule.tf
@@ -99,6 +99,13 @@ resource "aws_wafregional_rule" "restrict_sizes" {
   metric_name = "restrictsizes"
   tags        = var.tags
 
+# Don't do restrict_sizes for Concourse if requests originate from the VPN
+  predicate {
+    data_id = aws_wafregional_ipset.admin_remote_ipset.id
+    negated = true
+    type    = "IPMatch"
+  }
+
   predicate {
     data_id = aws_wafregional_size_constraint_set.size_restrictions.id
     negated = false


### PR DESCRIPTION
- The allows requests that originate from the VPN, to bypass the `restricted_size` rule on the WAF
- Restores the `restricted_size` rule to a much smaller number.