### PR TITLE
remove ITHC ips, add names to SGs

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -17,7 +17,7 @@ module "concourse_lb" {
   parent_domain_name     = local.parent_domain_name[local.environment]
   vpc                    = module.vpc.outputs
   wafregional_web_acl_id = module.waf.wafregional_web_acl_id
-  whitelist_cidr_blocks  = concat(var.whitelist_cidr_blocks, local.github_metadata.hooks, local.ithc_cidr_blocks)
+  whitelist_cidr_blocks  = concat(var.whitelist_cidr_blocks, local.github_metadata.hooks)
   logging_bucket         = data.terraform_remote_state.security-tools.outputs.logstore_bucket.id
 }
 

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -103,10 +103,6 @@ data "aws_secretsmanager_secret_version" "internet_ingress" {
 }
 
 locals {
-ithc_cidr_blocks = jsondecode(data.aws_secretsmanager_secret_version.internet_ingress.secret_binary)["ssh_bastion_whitelisted_ranges"]
-}
-
-locals {
   account = { {% for key, value in accounts.items() %}
     {{key}} = "{{value}}"{% endfor %}
   }

--- a/terraform/modules/database/security_groups.tf
+++ b/terraform/modules/database/security_groups.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "db" {
+  name = "${var.name}-db"
   vpc_id = var.vpc.aws_vpc.id
   tags   = merge(var.tags, { Name = "${var.name}-db" })
 }

--- a/terraform/modules/loadbalancer/security_groups.tf
+++ b/terraform/modules/loadbalancer/security_groups.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "lb" {
+  name   = "${var.name}-lb"
   vpc_id = var.vpc.aws_vpc.id
   tags   = merge(var.tags, { Name = "${var.name}-lb" })
 

--- a/terraform/modules/waf/waf_rule.tf
+++ b/terraform/modules/waf/waf_rule.tf
@@ -99,7 +99,7 @@ resource "aws_wafregional_rule" "restrict_sizes" {
   metric_name = "restrictsizes"
   tags        = var.tags
 
-# Don't do restrict_sizes for Concourse if requests originate from the VPN
+  # Don't do restrict_sizes for Concourse if requests originate from the VPN
   predicate {
     data_id = aws_wafregional_ipset.admin_remote_ipset.id
     negated = true


### PR DESCRIPTION
- Remove ITHC IPs from WAF.  No longer required.
- Add names to SGs that were missing.