### PR TITLE
Move GitHub access to view only

### DIFF
--- a/terraform/modules/concourse_web/templates/teams/dataworks/team.yml
+++ b/terraform/modules/concourse_web/templates/teams/dataworks/team.yml
@@ -2,6 +2,7 @@ roles:
   - name: member
     oidc:
       groups: ["dataworks"]
+  - name: viewer
     github:
       teams: ["dip:devops"]
   - name: owner

--- a/terraform/modules/concourse_web/templates/teams/utility/team.yml
+++ b/terraform/modules/concourse_web/templates/teams/utility/team.yml
@@ -2,6 +2,7 @@ roles:
   - name: member
     oidc:
       groups: ["dataworks"]
+  - name: viewer
     github:
       teams: ["dip:devops"]
   - name: owner


### PR DESCRIPTION
GitHub access is too open, so this moves all user access via GitHub to viewers only.