### PR TITLE
Deny by default

### DIFF
--- a/terraform/modules/waf/waf_web_acl.tf
+++ b/terraform/modules/waf/waf_web_acl.tf
@@ -8,7 +8,7 @@ resource "aws_wafregional_web_acl" "acl" {
   }
 
   default_action {
-    type = "ALLOW"
+    type = "BLOCK"
   }
 
   rule {


### PR DESCRIPTION
By default, we should block all traffic to the WAF.  the rules are there to let traffic pass on match.