### PR TITLE
Fix update-ami-secrets job, replace hardcode with bootstrap

### DIFF
--- a/bootstrap_terraform.py
+++ b/bootstrap_terraform.py
@@ -33,6 +33,8 @@ def main():
             SecretId="/concourse/dataworks/terraform")
         concourse_secret = secrets_manager.get_secret_value(
             SecretId="/concourse/dataworks/dataworks")
+        ami_ids = secrets_manager.get_secret_value(
+            SecretId="/concourse/dataworks/ami-ids")
     except botocore.exceptions.ClientError as e:
         error_message = e.response["Error"]["Message"]
         if "The security token included in the request is invalid" in error_message:
@@ -47,6 +49,10 @@ def main():
         terraform_secret['SecretBinary'], Loader=yaml.FullLoader)
     config_data['terraform'] = json.loads(
         terraform_secret['SecretBinary'])["terraform"]
+    config_data['concourse_ami'] = json.loads(
+        ami_ids['SecretBinary'])["concourse_ami"]
+    config_data['concourse_ami_mgmt_dev'] = json.loads(
+        ami_ids['SecretBinary'])["concourse_ami_mgmt_dev"]
     config_data['database_username'] = json.loads(
         dataworks_secret['SecretBinary'])["database_user"]
     config_data['database_password'] = json.loads(

--- a/ci/jobs/ami-id-update.yml
+++ b/ci/jobs/ami-id-update.yml
@@ -7,6 +7,8 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.management-dev)):role/ci
+          inputs:
+            - name: untested-al2-concourse-ami
   - name: ami-id-update-mgmt
     plan:
       - get: dw-al2-concourse-ami
@@ -15,3 +17,5 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.management)):role/ci
+          inputs:
+            - name: dw-al2-concourse-ami

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -94,14 +94,14 @@ meta:
              source /assume-role
 
              if [[ -d "untested-al2-concourse-ami" ]]; then
-                 CONCOURSE_AMI_MGMT_DEV=$(cat untested-al2-concourse-ami/id)
+                 CONCOURSE_AMI_MGMT_DEV=\"$(cat untested-al2-concourse-ami/id)\"
              else
                echo "No untested-al2-concourse-ami id available"
              fi
 
              if
                [[ -d "dw-al2-concourse-ami" ]]; then
-                 CONCOURSE_AMI=$(cat dw-al2-concourse-ami/id)
+                 CONCOURSE_AMI=\"$(cat dw-al2-concourse-ami/id)\"
              else
                echo "No dw-al2-concourse-ami id available"
              fi

--- a/ci/meta.yml
+++ b/ci/meta.yml
@@ -93,11 +93,11 @@ meta:
            - |
              source /assume-role
 
-             if [[ -d "untested-concourse-ami" ]]; then
-                 CONCOURSE_AMI_MGMT_DEV=$(cat untested-concourse-ami/id)
+             if [[ -d "untested-al2-concourse-ami" ]]; then
+                 CONCOURSE_AMI_MGMT_DEV=$(cat untested-al2-concourse-ami/id)
              else
-               echo "No untested-concourse-ami id available"
-             done
+               echo "No untested-al2-concourse-ami id available"
+             fi
 
              if
                [[ -d "dw-al2-concourse-ami" ]]; then
@@ -109,18 +109,18 @@ meta:
              if [[ -z "$CONCOURSE_AMI_MGMT_DEV" && -z "$CONCOURSE_AMI" ]]; then
                  echo "No available AMI IDs...Exiting"
                  exit 1
-             done
+             fi
 
-             echo $(aws secretsmanager get-secret-value --secret-id /concourse/dataworks/ami-ids --query SecretBinary --output text | base64 -D) > ami-ids.json
+             echo $(aws secretsmanager get-secret-value --secret-id /concourse/dataworks/ami-ids --query SecretBinary --output text | base64 -d) > ami-ids.json
 
              if [[ ! -z "$CONCOURSE_AMI_MGMT_DEV" ]]; then
-                 OLD_CONCOURSE_AMI_MGMT_DEV=$(cat ami-ids.json | jq '.concourse_ami')
-                 sed -i 's/$OLD_CONCOURSE_AMI_MGMT_DEV/$CONCOURSE_AMI_MGMT_DEV' ami-ids.json
-             done
+                 OLD_CONCOURSE_AMI_MGMT_DEV=$(cat ami-ids.json | jq '.concourse_ami_mgmt_dev')
+                 sed -i "s/$OLD_CONCOURSE_AMI_MGMT_DEV/$CONCOURSE_AMI_MGMT_DEV/" ami-ids.json
+             fi
              
              if [[ ! -z "$CONCOURSE_AMI" ]]; then
                OLD_CONCOURSE_AMI=$(cat ami-ids.json | jq '.concourse_ami')
-               sed -i 's/$OLD_CONCOURSE_AMI/$CONCOURSE_AMI' ami-ids.json
-             done
+               sed -i "s/$OLD_CONCOURSE_AMI/$CONCOURSE_AMI/" ami-ids.json
+             fi
 
              aws secretsmanager put-secret-value  --secret-id /concourse/dataworks/ami-ids --secret-binary fileb://ami-ids.json

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -159,7 +159,7 @@ locals {
 
   no_proxy = "${join(",", module.vpc.outputs.no_proxy_list)},${var.concourse_web_config.enterprise_github_url}"
 
-  ami_id = local.environment == "management" ? "ami-05c376e3e23319d73" : "ami-0a43b07f9f26c8cd2"
+  ami_id = local.environment == "management" ? var.concourse_ami : var.concourse_ami_mgmt_dev
 
   enterprise_github_certs = [
     "s3://dw-${local.environment}-public-certificates/ca_certificates/ucfs/ucd_ca.pem",

--- a/terraform/deploy/terraform.tfvars.j2
+++ b/terraform/deploy/terraform.tfvars.j2
@@ -5,6 +5,9 @@ whitelist_cidr_blocks    = [{% set doiranges = doi["cidr_blocks"].split(',') %}
   {% endfor %}"{{ucfs["team_cidr_block"]}}"
 ]
 
+concourse_ami = "{{concourse_ami}}"
+concourse_ami_mgmt_dev = "{{concourse_ami_mgmt_dev}}"
+
 concourse_web_config = {
   database_username = "{{database_username}}"
   database_password = "{{database_password}}"

--- a/terraform/deploy/variables.tf
+++ b/terraform/deploy/variables.tf
@@ -47,6 +47,16 @@ variable "ami_filter_name" {
   default = "name"
 }
 
+variable "concourse_ami" {
+  type    = string
+  default = ""
+}
+
+variable "concourse_ami_mgmt_dev" {
+  type    = string
+  default = ""
+}
+
 variable "concourse_no_proxy" {
   type    = string
   default = "169.254.169.254,169.254.169.123,.amazonaws.com"


### PR DESCRIPTION
- Fix bash
- Replaces hardcoded AMI IDs with those stored in secrets 