### PR TITLE
redact acc numbers from logs

### DIFF
--- a/.github/workflows/ami-test-apply.yml
+++ b/.github/workflows/ami-test-apply.yml
@@ -121,6 +121,15 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
 
+      - name: "Redact Logs AMI Test"
+        if: failure()
+        id: redact-logs-ami-test
+        run: |
+              sed -i 's/$ACC_MGMT_DEV/REDACTED/g' ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
+        shell: bash
+        env:
+          ACC_MGMT_DEV: ${{ secrets.AWS_GHA_ACC_MGMT_DEV }}
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -88,6 +88,15 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
 
+      - name: "Redact Logs MGMT-DEV"
+        if: failure()
+        id: redact-logs-mgmt-dev
+        run: |
+              sed -i 's/$ACC_MGMT_DEV/REDACTED/g' ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
+        shell: bash
+        env:
+          ACC_MGMT_DEV: ${{ secrets.AWS_GHA_ACC_MGMT_DEV }}
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
@@ -169,6 +178,15 @@ jobs:
           AWS_REGION: eu-west-2
           AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+
+      - name: "Redact Logs MGMT"
+        if: failure()
+        id: redact-logs-mgmt
+        run: |
+              sed -i 's/$ACC_MGMT/REDACTED/g' ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
+        shell: bash
+        env:
+          ACC_MGMT: ${{ secrets.AWS_GHA_ACC_MGMT }}
 
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/tf-pull-request.yml
+++ b/.github/workflows/tf-pull-request.yml
@@ -71,6 +71,15 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
 
+      - name: "Redact Logs MGMT PR"
+        if: failure()
+        id: redact-logs-mgmt-pr
+        run: |
+              sed -i 's/$ACC_MGMT/REDACTED/g' ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
+        shell: bash
+        env:
+          ACC_MGMT: ${{ secrets.AWS_GHA_ACC_MGMT }}
+
       - uses: actions/upload-artifact@v2
         if: failure()
         with:


### PR DESCRIPTION
We create artifacts on failed GHA workflows, that contain logs allowing for debugging.  This job should redact account numbers from the log before being published as an artifact.