### PR TITLE
remove ipv6 entries

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -9,7 +9,7 @@ module "concourse_lb" {
   parent_domain_name     = local.parent_domain_name[local.environment]
   vpc                    = module.vpc.outputs
   wafregional_web_acl_id = module.waf.wafregional_web_acl_id
-  whitelist_cidr_blocks  = concat(var.whitelist_cidr_blocks, local.github_metadata.hooks)
+  whitelist_cidr_blocks  = local.whitelist_cidr_blocks
   logging_bucket         = data.terraform_remote_state.security-tools.outputs.logstore_bucket.id
 }
 
@@ -163,7 +163,7 @@ module "vpc" {
   name                        = var.name
   tags                        = local.tags
   vpc_cidr_block              = local.cidr_block[local.environment].ci-cd-vpc
-  whitelist_cidr_blocks       = concat(var.whitelist_cidr_blocks, local.github_metadata.hooks)
+  whitelist_cidr_blocks       = local.whitelist_cidr_blocks
   internet_proxy_fqdn         = module.vpc.outputs.internet_proxy_endpoint
   internet_proxy_service_name = data.terraform_remote_state.internet_egress.outputs.internet_proxy_service.service_name
   vpc_endpoint_source_sg_ids  = [module.concourse_web.outputs.security_group.id, module.concourse_worker.outputs.security_group.id]

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -115,6 +115,10 @@ data "aws_secretsmanager_secret_version" "internet_ingress" {
 locals {
   github_metadata = jsondecode(data.http.github.body)
 
+  full_cidr_blocks  = concat(var.whitelist_cidr_blocks, local.github_metadata.hooks)
+
+  whitelist_cidr_blocks = [ for v in local.full_cidr_blocks : v if replace(v, ":", "") == v ]
+
   account = { {% for key, value in accounts.items() %}
     {{key}} = "{{value}}"{% endfor %}
   }


### PR DESCRIPTION
GitHub added IPV6 CIDR blocks to their metadata.  We lazily parsed this for IPV4 addresses.  The new additions broke the terraform resources, only expecting IPV4 entries.  This removes those entries.