### PR TITLE
remove incorrect endpoint service.  Attempt to fix WAF rules

### DIFF
--- a/terraform/deploy/modules.tf
+++ b/terraform/deploy/modules.tf
@@ -186,6 +186,6 @@ module "waf" {
   whitelist_cidr_blocks = var.whitelist_cidr_blocks
   log_bucket            = data.terraform_remote_state.security-tools.outputs.logstore_bucket.arn
   cloudwatch_log_group  = "/${var.name}/waf"
-  github_metadata       = local.github_metadata
+  github_metadata       = local.github_hooks
   tags                  = local.tags
 }

--- a/terraform/deploy/terraform.tf.j2
+++ b/terraform/deploy/terraform.tf.j2
@@ -119,6 +119,8 @@ locals {
 
   whitelist_cidr_blocks = [ for v in local.full_cidr_blocks : v if replace(v, ":", "") == v ]
 
+  github_hooks = [for v in local.github_metadata.hooks : v if replace(v, ":", "") == v]
+
   account = { {% for key, value in accounts.items() %}
     {{key}} = "{{value}}"{% endfor %}
   }

--- a/terraform/modules/vpc/vpc.tf
+++ b/terraform/modules/vpc/vpc.tf
@@ -39,7 +39,6 @@ module "vpc" {
     "sqs",
     "ssm",
     "ssmmessages",
-    var.ap_service_name,
   ]
   common_tags = merge(var.tags, { Name = var.name })
 }

--- a/terraform/modules/waf/waf_condition_github.tf
+++ b/terraform/modules/waf/waf_condition_github.tf
@@ -3,7 +3,7 @@ resource "aws_wafregional_ipset" "github_com_ipset" {
   name = "match-github-com-ip"
 
   dynamic "ip_set_descriptor" {
-    for_each = var.github_metadata.hooks
+    for_each = var.github_metadata
 
     content {
       value = ip_set_descriptor.value


### PR DESCRIPTION
remove incorrect endpoint service.
Add individual `local` for the github hooks block used by the WAF module. Currently broken trying to import ipv6 addresses into ipv4 only slots.