### PR TITLE
no creds required, breaks it

### DIFF
--- a/ci/ami-test/resources.yml
+++ b/ci/ami-test/resources.yml
@@ -21,6 +21,5 @@ resources:
     source:
       owner: dwp
       repository: aws-concourse
-      access_token: ((dataworks-secrets.concourse_github_pat))
     check_every: 5m
     webhook_token: ((dataworks.concourse_github_webhook_token))


### PR DESCRIPTION
Signed-off-by: Chris Scott-Thomas <chrisscott-thomas@digital.uc.dwp.gov.uk>